### PR TITLE
Pass arguments to system constructors

### DIFF
--- a/src/picoes.js
+++ b/src/picoes.js
@@ -76,9 +76,9 @@ class World {
 	// Registers a system to the world
 	// Returns its unique ID on success or undefined on failure
 	// world.system(class { every(ent) {} })
-	system(components, systemClass) {
+	system(components, systemClass, ...args) {
 		if (isFunction(systemClass)) {
-			let newSystem = new systemClass()
+			let newSystem = new systemClass(...args)
 			newSystem.components = components
 			this.systems.push(newSystem)
 			return this.systems.length - 1

--- a/test/tests.js
+++ b/test/tests.js
@@ -289,6 +289,17 @@ describe('World', function() {
 			world.system(['position'], class {})
 			assert(world.systems.length == 1)
 		})
+		it('define a system with arguments', function() {
+			let world = new World()
+			let velocitySystem = class {
+				constructor(maxVelocity) {
+					this.maxVelocity = maxVelocity
+				}
+			}
+			world.component('velocity')
+			world.system(['velocity'], velocitySystem, 3500)
+			assert(world.systems[0].maxVelocity === 3500)
+		})
 		it('system iteration', function() {
 			let world = new World()
 			world.component('position')


### PR DESCRIPTION
I'm looking to have a simple sprite renderer system, that takes everything with a sprite and position and renders it to a canvas context.  But I'm at a loss at how to get the context in there, especially since I'm using ES6 modules. (And I'd rather avoid the pattern of import factory and then pass arguments and get a class wrapped in a closure.)

In my mind, it'd work like this:

First I define the renderer system, which takes a context argument in its constructor:
```javascript
export default class Renderer {
    constructor(context) {
        this.context = context;
    }

    every(sprite, position) {
        context.drawImage(sprite.image, position.x, position.y);
    }
}
```

Then I use a syntax similar to how components are initialized to pass arguments through:
```javascript
world.system(['sprite', 'position'], Renderer, context);
```

What do you think?  It doesn't take much to get this working, but maybe there's a better alternative that I'm missing.